### PR TITLE
Update pipelines with latest versions of actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ^1.18
+        go-version: ^1.19
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,7 +27,7 @@ jobs:
 
             if(!releaseBranchName) { return false }
 
-            const {data: prs} = await github.pulls.list({
+            const {data: prs} = await github.rest.pulls.list({
                 ...context.repo,
                 state: 'open',
                 head: `1Password:${releaseBranchName}`,

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - id: is_release_branch_without_pr
         name: Find matching PR
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -42,7 +42,7 @@ jobs:
     name: Create Release Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Parse release version
         id: get_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,14 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      -
-        name: Docker meta
+
+      - name: Docker meta
         id: meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v4
         with:
           images: |
             1password/kubernetes-secrets-injector
@@ -29,24 +28,25 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+
       - name: Get the version from tag
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Docker Login
-        uses: docker/login-action@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker Login
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
This PR updates the following GitHub Actions used:
| GitHub Action Name | Old version | New version | Notes |
| :-------------------: | :----------: | :-----------: | :-----: |
| `actions/checkout`   | `v2`            | `v3`              |             |
| `actions/setup-go`   | `v2`            | `v3`              |             |
| `actions/github-script`   | `v3`     | `v6`              |             |
| `docker/metadata-action` | `v2`  | `v4`              |  Previously named <br> `crazy-max/ghaction-docker-meta` |
| `docker/setup-qemu-action`| `v1`| `v2`             |             |
| `docker/setup-buildx-action` | `v1` | `v2`          |             |
| `docker/login-action` | `v1`          | `v2`               |             |
| `docker/build-push-action` | `v1` | `v2`             |             |
