### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ spec:
       containers:
         - name: app-example1
           image: my-image
+          ports:
+            - containerPort: 5000
+          command: ["npm"]
+          args: ["start"]
           # This app will have the secrets injected using Connect.
           env:
           - name: OP_CONNECT_HOST
@@ -47,14 +51,22 @@ spec:
           - name: DB_PASSWORD
             value: op://my-vault/my-item/sql/password
 
-        - name: my-app //because my-app is not listed in the inject annotation above this container will not be injected with secrets
+        - name: my-app #because my-app is not listed in the inject annotation above this container will not be injected with secrets
           image: my-image
+          ports:
+            - containerPort: 5000
+          command: ["npm"]
+          args: ["start"]
           env:
           - name: DB_USERNAME
             value: op://my-vault/my-item/sql/username
           - name: DB_PASSWORD
             value: op://my-vault/my-item/sql/password
 ```
+**Note**: injected secrets are available in the current pod's session only.
+
+In the example above the `app-example1` container will have injected `DB_USERNAME` and `DB_PASSWORD` values.
+But if you try to access them in a new session (for example using `kubectl exec`) it would return 1password item path (aka `op://my-vault/my-item/sql/password`).
 
 ## Setup and Deployment
 

--- a/README.md
+++ b/README.md
@@ -64,16 +64,12 @@ spec:
             value: op://my-vault/my-item/sql/password
 ```
 
-{% note %}
-
 **Note:** Injected secrets are available *only* in the current pod's session.
 
-**Note:** In the example above the `app-example1` container will have injected the `DB_USERNAME` and `DB_PASSWORD` values in the session executed by the command `npm start`.
-**Note:** If you want to access them in a new session (for example using `kubectl exec`) you should append `op run --` to the command executed in the container's new session.
+In the example above the `app-example1` container will have injected the `DB_USERNAME` and `DB_PASSWORD` values in the session executed by the command `npm start`.
+If you want to access them in a new session (for example using `kubectl exec`) you should append `op run --` to the command executed in the container's new session.
 
-**Note:** Another alternative to have the secrets available in all container's sessions is by using the [1Password Kubernetes Operator](https://github.com/1password/onepassword-operator).
-
-{% endnote %}
+Another alternative to have the secrets available in all container's sessions is by using the [1Password Kubernetes Operator](https://github.com/1password/onepassword-operator).
 
 ## Setup and Deployment
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,17 @@ spec:
           - name: DB_PASSWORD
             value: op://my-vault/my-item/sql/password
 ```
-**Note**: injected secrets are available *only* in the current pod's session.
 
-In the example above the `app-example1` container will have injected the `DB_USERNAME` and `DB_PASSWORD` values in the session executed by the command `npm start`.
-If you want to access them in a new session (for example using `kubectl exec`) you should append `op run --` to the command executed in the container's new session.
+{% note %}
 
-Another alternative to have the secrets available in all container's sessions is by using the [1Password Kubernetes Operator](https://github.com/1password/onepassword-operator).
+**Note:** Injected secrets are available *only* in the current pod's session.
+
+**Note:** In the example above the `app-example1` container will have injected the `DB_USERNAME` and `DB_PASSWORD` values in the session executed by the command `npm start`.
+**Note:** If you want to access them in a new session (for example using `kubectl exec`) you should append `op run --` to the command executed in the container's new session.
+
+**Note:** Another alternative to have the secrets available in all container's sessions is by using the [1Password Kubernetes Operator](https://github.com/1password/onepassword-operator).
+
+{% endnote %}
 
 ## Setup and Deployment
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ spec:
           - name: DB_PASSWORD
             value: op://my-vault/my-item/sql/password
 ```
-**Note**: injected secrets are available in the current pod's session only.
+**Note**: injected secrets are available *only* in the current pod's session.
 
 In the example above the `app-example1` container will have injected `DB_USERNAME` and `DB_PASSWORD` values.
 But if you try to access them in a new session (for example using `kubectl exec`) it would return 1password item path (aka `op://my-vault/my-item/sql/password`).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ spec:
           - name: DB_PASSWORD
             value: op://my-vault/my-item/sql/password
 
-        - name: my-app #because my-app is not listed in the inject annotation above this container will not be injected with secrets
+        - name: my-app # because my-app is not listed in the inject annotation above this container will not be injected with secrets
           image: my-image
           ports:
             - containerPort: 5000

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ spec:
 ```
 **Note**: injected secrets are available *only* in the current pod's session.
 
-In the example above the `app-example1` container will have injected `DB_USERNAME` and `DB_PASSWORD` values.
-But if you try to access them in a new session (for example using `kubectl exec`) it would return 1password item path (aka `op://my-vault/my-item/sql/password`).
+In the example above the `app-example1` container will have injected the `DB_USERNAME` and `DB_PASSWORD` values in the session executed by the command `npm start`.
+If you want to access them in a new session (for example using `kubectl exec`) you should append `op run --` to the command executed in the container's new session.
+
+Another alternative to have the secrets available in all container's sessions is by using the [1Password Kubernetes Operator](https://github.com/1password/onepassword-operator).
 
 ## Setup and Deployment
 


### PR DESCRIPTION
Resolves #20 

Mention the case that inject env variables are avaialble only in the current terminal session (the on that started the container). If try to access those env vars using new session it will return the 1password item path instead of inject value.

The workaround for that can be prepending the command with `op run`: 
```
kubectl exec \
   $(kubectl get pod -l app=app-example -o jsonpath="{.items[0].metadata.name}") \
   --container app-example1 -- /op/bin/op run -- printenv USERNAME PASSWORD
```

Or try to use 1password-operator to create k8s secret containing 1password item and access it from any terminal session.