### PR TITLE
Fix/22/volume mounts override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SCRIPTS_DIR := $(CURDIR)/scripts
 versionFile = $(CURDIR)/.VERSION
 curVersion := $(shell cat $(versionFile) | sed 's/^v//')
 
-INJECTOR_NAME := kubernetes-secrets-injector
+INJECTOR_NAME := 1password/kubernetes-secrets-injector
 INJECTOR_DOCKER_IMG_TAG ?= $(INJECTOR_NAME):v$(curVersion)
 
 test:	## Run test suite

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -386,7 +386,7 @@ func (s *SecretInjector) mutateContainer(cxt context.Context, container *corev1.
 	patch = append(patch, patchOperation{
 		Op:    "add",
 		Path:  path,
-		Value: []corev1.VolumeMount{binVolumeMount},
+		Value: append(container.VolumeMounts, binVolumeMount),
 	})
 
 	// replacing the container command with a command prepended with op run


### PR DESCRIPTION
Reloves #22 

This PR fixes the issue with overriding volumeMounts for containers which are used `op-cli` to inject secrets.

Instead of applying only `op` volumeMount to the mutated container, it appends it to the existing volumeMounts.


Test steps:
1. Deploy injector, connect and you application pod (make sure application pod has mounted volumes for example redis. You can grab the app pod spec from [the issue description](https://github.com/1Password/kubernetes-secrets-injector/issues/22)
2. Verify that the secrets are injected into you application pod successfully (if you used the pod spec from the issue description just run  `kubectl logs app-example-podname --namespace <namespace>` the logs should print `<Concealed by 1Password>`).
3. Run `kubectl describe pod <pod-name> --namespace <namespace>` and check **Mounts** section. It should contain `op` mount along with `redis`. Something like
```
Mounts:
      /etc/redis from redis (rw)
      /op/bin/ from op-bin (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-nmcmv (ro)
```
Note that before that fix, there were no `redis` entry in the **Mounts**.