### PR TITLE
Remove 'BETA' references from Service Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Read more on the [1Password Developer Portal](https://developer.1password.com/co
 - [Usage](#usage)
 - [Setup and deployment](#setup-and-deployment)
 - [Use with 1Password Connect](#use-with-1password-connect)
-- [Use with 1Password Service Accounts](#use-with-1password-service-accounts-supbetasup)
+- [Use with 1Password Service Accounts](#use-with-1password-service-accounts)
 - [Troubleshooting](#troubleshooting)
 - [Security](#security)
 
@@ -145,7 +145,7 @@ Then, follow instructions to [use the Kubernetes Injector](#use-with-1password-c
 If you want to use 1Password Service Accounts:
 - [Create a service account.](https://developer.1password.com//docs/service-accounts/)
 
-Then, follow instructions to [use the Kubernetes Injector with a service account](#use-with-1password-service-accounts-supbetasup).
+Then, follow instructions to [use the Kubernetes Injector with a service account](#use-with-1password-service-accounts).
 
 ## Use with 1Password Connect
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spec:
             - containerPort: 5000
           command: ["npm"]
           args: ["start"]
-          # A 1Password Connect server (currently in beta) will inject secrets into this application.
+          # A 1Password Connect server will inject secrets into this application.
           env:
           - name: OP_CONNECT_HOST
             value: http://onepassword-connect:8080

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ annotations:
 ```
 
 ### Step 5: Annotate your client pod or deployment with `version` annotation
-Annotate your client pod or deployment with the latest version of the 1Password CLI.
+Annotate your client pod or deployment with the latest version of the 1Password CLI (`2.18.0` or later).
 ```yaml
 # client-deployment.yaml
 annotations:

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ annotations:
 ```
 
 ### Step 5: Annotate your client pod or deployment with `version` annotation
-Annotate your client pod or deployment with the latest 1Password CLI beta version (`2.16.0-beta.01` or later).
+Annotate your client pod or deployment with the latest version of the 1Password CLI.
 ```yaml
 # client-deployment.yaml
 annotations:

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 The 1Password Secrets Injector implements a mutating webhook to inject 1Password secrets as environment variables into a Kubernetes pod or deployment. Unlike the [1Password Kubernetes Operator](https://github.com/1Password/onepassword-operator), the Secrets Injector doesn't create a Kubernetes Secret when assigning secrets to your resource.
 
-The 1Password Secrets Injector for Kubernetes can use [1Password Connect](https://developer.1password.com/docs/connect) or [1Password Service Accounts <sup>BETA</sup>](https://developer.1password.com/docs/service-accounts) to retrieve items.
+The 1Password Secrets Injector for Kubernetes can use [1Password Connect](https://developer.1password.com/docs/connect) or [1Password Service Accounts](https://developer.1password.com/docs/service-accounts) to retrieve items.
 
 Read more on the [1Password Developer Portal](https://developer.1password.com/connect/k8s-injector).
 
 - [Usage](#usage)
 - [Setup and deployment](#setup-and-deployment)
 - [Use with 1Password Connect](#use-with-1password-connect)
-- [Use with 1Password Service Account <sup>BETA</sup>](#use-with-1password-service-accounts-supbetasup)
+- [Use with 1Password Service Account](#use-with-1password-service-accounts-supbetasup)
 - [Troubleshooting](#troubleshooting)
 - [Security](#security)
 
@@ -68,7 +68,7 @@ spec:
 ```
 
 <details>
-<summary>Usage with 1Password Service Accounts <sup>BETA</sup></summary>
+<summary>Usage with 1Password Service Accounts</summary>
 
 ```yaml
 # client-deployment.yaml - The client deployment/pod where you want to inject secrets
@@ -96,7 +96,7 @@ spec:
             - containerPort: 5000
           command: ["npm"]
           args: ["start"]
-          # A 1Password Service Account (currently in beta) will inject secrets into this application.
+          # A 1Password Service Account will inject secrets into this application.
           env:
           - name: OP_SERVICE_ACCOUNT_TOKEN
             valueFrom:
@@ -142,7 +142,7 @@ If you want to use 1Password Connect:
 
 Then, follow instructions to [use the Kubernetes Injector](#use-with-1password-connect).
 
-If you want to use 1Password Service Accounts <sup>BETA</sup>:
+If you want to use 1Password Service Accounts:
 - [Create a service account.](https://developer.1password.com//docs/service-accounts/)
 
 Then, follow instructions to [use the Kubernetes Injector with a service account](#use-with-1password-service-accounts-supbetasup).
@@ -205,7 +205,7 @@ env:
     value: op://my-vault/my-item/sql/username
 ```
 
-## Use with 1Password Service Accounts <sup>BETA</sup>
+## Use with 1Password Service Accounts
 
 ### Step 1: Create a Kubernetes secret containing `OP_SERVICE_ACCOUNT_TOKEN`
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Read more on the [1Password Developer Portal](https://developer.1password.com/co
 - [Usage](#usage)
 - [Setup and deployment](#setup-and-deployment)
 - [Use with 1Password Connect](#use-with-1password-connect)
-- [Use with 1Password Service Account](#use-with-1password-service-accounts-supbetasup)
+- [Use with 1Password Service Accounts](#use-with-1password-service-accounts-supbetasup)
 - [Troubleshooting](#troubleshooting)
 - [Security](#security)
 


### PR DESCRIPTION
- This PR removes the `BETA` references from mentions of Service Accounts in the `README.md` file.
- It specifies that the minimum 1Password CLI version is 2.18.0 to use Service Accounts.
- It can be merged after Service Accounts have exited beta and entered general availability (GA).

## Additional Notes

This PR includes the following related fixes in the `README.md` file:

1. There was a code comment that includes `1Password Connect server (currently in beta)`; I've removed the `(currently in beta)` text since Connect has been GA for a long time.
2. The `Use with 1Password Service Accounts` link has been pluralized to match its associated heading.
3. The `use-with-1password-service-accounts-supbetasup` link was broken due to the `supbetasup` part on the end; this has been fixed in two places so that the link works correctly.
4. The requirement to use a beta version of the 1Password CLI has been updated to instruct users to use the latest version of the CLI.

## Questions

1. We have two instances of `operator.1password.io/version: "2-beta"` - do these need to be modified? (I'm assuming not, but wanted to raise this here just to confirm.) The thing that I'm unsure of is the `Annotate your client pod or deployment with the latest 1Password CLI beta version (2.16.0-beta.01 or later)` instruction above the code block example - does the `2-beta` refer to the CLI version here?