### PR TITLE
fix(webhook): config not updated upon changes

### DIFF
--- a/pkg/webhook/k8s_client.go
+++ b/pkg/webhook/k8s_client.go
@@ -103,15 +103,16 @@ func CreateOrUpdateMutatingWebhookConfiguration(caPEM *bytes.Buffer, webhookServ
 		return err
 	} else {
 		// there is an existing mutatingWebhookConfiguration
-		if reflect.DeepEqual(foundWebhookConfig, mutatingWebhookConfig) {
+		if !reflect.DeepEqual(foundWebhookConfig, mutatingWebhookConfig) {
 			mutatingWebhookConfig.ObjectMeta.ResourceVersion = foundWebhookConfig.ObjectMeta.ResourceVersion
 			if _, err := mutatingWebhookConfigV1Client.MutatingWebhookConfigurations().Update(context.TODO(), mutatingWebhookConfig, metav1.UpdateOptions{}); err != nil {
 				glog.Warningf("Failed to update the mutatingwebhookconfiguration: %s", webhookConfigName)
 				return err
 			}
 			glog.Infof("Updated the mutatingwebhookconfiguration: %s", webhookConfigName)
+		} else {
+			glog.Infof("The mutatingwebhookconfiguration: %s already exists and has no change", webhookConfigName)
 		}
-		glog.Infof("The mutatingwebhookconfiguration: %s already exists and has no change", webhookConfigName)
 	}
 
 	return nil


### PR DESCRIPTION
Due to a bug in the mutatingwebhookconfig update logic, the `secrets-injector-webhook-config` mutatingwebhookconfig object needs to be deleted manually every time the application restarts.

The reason is that, on every startup, a new CA bundle is created and needs to be applied to the existing mutatingwebhookconfig. Right now, the `caBunble` in the mutatingwebhookconfig retains its original value although the application has regenerated its CA bundle, and TLS handshakes from the Kubernetes control plane fail.

Fixes #32