### PR TITLE
fix: update imagePullPolicy to IfNotPresent

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: secrets-injector
           image: 1password/kubernetes-secrets-injector:latest
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           args:
           - -service-name=secrets-injector
           - -alsologtostderr


### PR DESCRIPTION
It appears that the **ImagePullPolicy** for the Injector has been set to "**Never**!" which may result in deployment failures in most cases. To avoid this, it is recommended and safest to set it to "**IfNotPresent**". 

Not sure why 1password set it to **Never** :(

Resolves #37.