### PR TITLE
fix: parse flags before logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,15 +25,14 @@ func init() {
 }
 
 func main() {
-	webhook.InitK8sClient()
-
 	var parameters webhook.SecretInjectorParameters
-
-	glog.Info("Starting webhook")
-	// get command line parameters
 	flag.IntVar(&parameters.Port, "port", 8443, "Webhook server port.")
 	flag.StringVar(&webhookServiceName, "service-name", "secrets-injector-svc", "Webhook service name.")
 	flag.Parse()
+
+	glog.Info("Starting webhook")
+
+	webhook.InitK8sClient()
 
 	dnsNames := []string{
 		webhookServiceName,

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -21,9 +21,8 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
           - -service-name=secrets-injector
-          - -alsologtostderr
+          - -logtostderr
           - -v=4
-          - 2>&1
           env:
           - name: POD_NAMESPACE
             valueFrom:


### PR DESCRIPTION
glog never has the opportunity to read the given flags, and will therefore create a temporary log file even if explicitly disabled.

Fixes: #45